### PR TITLE
ORG-45 Fix code quality issues

### DIFF
--- a/cmd/opts/serve.go
+++ b/cmd/opts/serve.go
@@ -1,8 +1,13 @@
 package opts
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/cors"
@@ -109,9 +114,25 @@ func Serve(cmd *cobra.Command, args []string) {
 			r.Get("/{ehid}/history", memberController.GetHistory)
 		})
 
-		err := http.ListenAndServe(fmt.Sprintf(":%d", configService.GetPort()), r)
+		srv := &http.Server{
+			Addr:    fmt.Sprintf(":%d", configService.GetPort()),
+			Handler: r,
+		}
 
-		if err != nil {
+		quit := make(chan os.Signal, 1)
+		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+		go func() {
+			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				panic(err)
+			}
+		}()
+
+		<-quit
+
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutdownCancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
 			panic(err)
 		}
 	}

--- a/internal/config/repository.go
+++ b/internal/config/repository.go
@@ -40,11 +40,21 @@ func NewRepository() Repository {
 
 	var readDsn = ""
 	for key, value := range viper.GetStringMapString("app.datasource.read") {
+		if key == "password" {
+			if env := os.Getenv("DB_READ_PASSWORD"); env != "" {
+				value = env
+			}
+		}
 		readDsn += string(key + "=" + value + " ")
 	}
 
 	var writeDsn = ""
 	for key, value := range viper.GetStringMapString("app.datasource.write") {
+		if key == "password" {
+			if env := os.Getenv("DB_WRITE_PASSWORD"); env != "" {
+				value = env
+			}
+		}
 		writeDsn += string(key + "=" + value + " ")
 	}
 

--- a/internal/designation/controller.go
+++ b/internal/designation/controller.go
@@ -17,9 +17,10 @@ type Controller struct {
 	DesignationService *Service
 }
 
-func NewController(cfg *config.Service, svc *Service) *Controller {
+func NewController(cfg *config.Service, es *localerror.Service, svc *Service) *Controller {
 	return &Controller{
 		ConfigService:      cfg,
+		LocalErrorService:  es,
 		DesignationService: svc,
 	}
 }

--- a/internal/node/controller.go
+++ b/internal/node/controller.go
@@ -182,7 +182,7 @@ func (c *Controller) GetLineage(w http.ResponseWriter, r *http.Request) {
 // @Description Get siblings and ancestral siblings of a node
 // @Produce json
 // @Param id path string true "Node ID"
-// @Success 200 {object} GetLineagelSiblingsResponseDto "Success Response"
+// @Success 200 {object} GetLineageSiblingsResponseDto "Success Response"
 // @Failure 400 "BadRequest"
 // @Failure 500 "InternalServerError"
 // @Router /nodes/{id}/lineage-siblings [GET]

--- a/internal/node/dto.go
+++ b/internal/node/dto.go
@@ -25,6 +25,6 @@ type PatchResponseDto = dtorespwithoutdata.Class
 type DeleteResponseDto = dtorespwithoutdata.Class
 type GetChildrenResponseDto = dtorespwithdata.Class[[]Entity]
 type GetLineageResponseDto = dtorespwithdata.Class[tree.Node[Entity]]
-type GetLineagelSiblingsResponseDto = dtorespwithdata.Class[tree.Node[Entity]]
+type GetLineageSiblingsResponseDto = dtorespwithdata.Class[tree.Node[Entity]]
 type GetOfficersResponseDto = dtorespwithdata.Class[[]designation.Entity]
 type GetMembersResponseDto = dtorespwithdata.Class[[]membership.ViewEntity]


### PR DESCRIPTION
## Summary
- Fix nil `LocalErrorService` injection in `designation.NewController` (would cause runtime panic)
- Fix typo `GetLineagelSiblingsResponseDto` → `GetLineageSiblingsResponseDto` in `node/dto.go` and Swagger annotation
- Add graceful shutdown on SIGINT/SIGTERM with a 10s drain timeout
- Allow DB passwords to be overridden via `DB_READ_PASSWORD` / `DB_WRITE_PASSWORD` env vars instead of hardcoded YAML values

## Test plan
- [ ] Server starts and responds to requests normally
- [ ] `kill -SIGTERM <pid>` shuts down cleanly without abrupt connection drops
- [ ] Setting `DB_READ_PASSWORD` / `DB_WRITE_PASSWORD` env vars overrides YAML password
- [ ] Swagger docs reflect the corrected `GetLineageSiblingsResponseDto` type name after regeneration (`make docs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)